### PR TITLE
Enable Azure sinks and enable tests for .NET Core

### DIFF
--- a/package.props
+++ b/package.props
@@ -21,7 +21,7 @@
     <NewtonsoftJsonVersion>11.0.*</NewtonsoftJsonVersion>
     <MicrosoftDataServicesClientVersion>5.8.*</MicrosoftDataServicesClientVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>1.0.15</MicrosoftDiagnosticsTracingTraceEventVersion>
-    <WindowsAzureStorageVersion>9.1.*</WindowsAzureStorageVersion>
+    <WindowsAzureStorageVersion>9.3.*</WindowsAzureStorageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/package.props
+++ b/package.props
@@ -27,7 +27,7 @@
   <PropertyGroup>
     <!--In order to debug the EntLib dependencies open 'SemanticLogging (With Dependencies).sln' and change 'EntLibDependencyType' value to Project -->
     <EntLibDependencyType>Package</EntLibDependencyType>
-    <EntLibTransientFaultHandlingVersion>6.1.*</EntLibTransientFaultHandlingVersion>
+    <EntLibTransientFaultHandlingVersion>6.0.*</EntLibTransientFaultHandlingVersion>
   </PropertyGroup>
 
 </Project>

--- a/source/Src/SemanticLogging.Database/SemanticLogging.Database.csproj
+++ b/source/Src/SemanticLogging.Database/SemanticLogging.Database.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;net47;netstandard2.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;net47;netstandard2.0;netcoreapp2.0</TargetFrameworks>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <FileVersion>$(Version).$(Revision)</FileVersion>
@@ -31,10 +31,10 @@
 
   <ItemGroup>
     <ProjectReference Include="$(EntLibTransientFaultHandling)" Condition="Exists('$(EntLibTransientFaultHandling)') AND '$(EntLibDependencyType)' == 'Project'" />
-    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling" Version="$(EntLibTransientFaultHandlingVersion)" Condition="!Exists('$(EntLibTransientFaultHandling)') OR '$(EntLibDependencyType)' == 'Package'" />
+    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.NetCore" Version="$(EntLibTransientFaultHandlingVersion)" Condition="!Exists('$(EntLibTransientFaultHandling)') OR '$(EntLibDependencyType)' == 'Package'" />
 
     <ProjectReference Include="$(EntLibTransientFaultHandlingData)" Condition="Exists('$(EntLibTransientFaultHandlingData)') AND '$(EntLibDependencyType)' == 'Project'" />
-    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Data" Version="$(EntLibTransientFaultHandlingVersion)" Condition="!Exists('$(EntLibTransientFaultHandlingData)') OR '$(EntLibDependencyType)' == 'Package'" />
+    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Data.NetCore" Version="$(EntLibTransientFaultHandlingVersion)" Condition="!Exists('$(EntLibTransientFaultHandlingData)') OR '$(EntLibDependencyType)' == 'Package'" />
 
     <ProjectReference Include="..\SemanticLogging\SemanticLogging.csproj" />
   </ItemGroup>
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' AND '$(TargetFramework)' != 'netcoreapp2.0'">
-
+    <Reference Include="System.Transactions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Src/SemanticLogging.Database/Sinks/SqlDatabaseSink.cs
+++ b/source/Src/SemanticLogging.Database/Sinks/SqlDatabaseSink.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnterpriseLibrary.SemanticLogging.Database.Utility;
 using EnterpriseLibrary.SemanticLogging.Utility;
-using EnterpriseLibrary.TransientFaultHandling;
+using Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling;
 
 namespace EnterpriseLibrary.SemanticLogging.Sinks
 {

--- a/source/Src/SemanticLogging.Etw/Configuration/ExtensionsLoader.cs
+++ b/source/Src/SemanticLogging.Etw/Configuration/ExtensionsLoader.cs
@@ -40,7 +40,7 @@ namespace EnterpriseLibrary.SemanticLogging.Etw.Configuration
         }
 
         /// <summary>
-        /// Gets the event listener elements that derives from base class <see cref="SinkElement"/>.
+        /// Gets the event listener elements that derives from base class <see cref="ISinkElement"/>.
         /// </summary>
         internal IEnumerable<Lazy<ISinkElement>> SinkElements
         {
@@ -48,7 +48,7 @@ namespace EnterpriseLibrary.SemanticLogging.Etw.Configuration
         }
 
         /// <summary>
-        /// Gets the event text formatter elements that derives from type <see cref="FormatterElement"/>.
+        /// Gets the event text formatter elements that derives from type <see cref="IFormatterElement"/>.
         /// </summary>
         internal IEnumerable<Lazy<IFormatterElement>> FormatterElements
         {

--- a/source/Src/SemanticLogging.WindowsAzure/SemanticLogging.WindowsAzure.csproj
+++ b/source/Src/SemanticLogging.WindowsAzure/SemanticLogging.WindowsAzure.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SemanticLogging\SemanticLogging.csproj" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0" />
   
     <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
     <PackageReference Include="Microsoft.Data.Services.Client" Version="$(MicrosoftDataServicesClientVersion)" />

--- a/source/Src/SemanticLogging.WindowsAzure/SemanticLogging.WindowsAzure.csproj
+++ b/source/Src/SemanticLogging.WindowsAzure/SemanticLogging.WindowsAzure.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;net47</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net47;netstandard2.0</TargetFrameworks>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <FileVersion>$(Version).$(Revision)</FileVersion>
@@ -26,6 +26,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SemanticLogging\SemanticLogging.csproj" />
+  
+    <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
+    <PackageReference Include="Microsoft.Data.Services.Client" Version="$(MicrosoftDataServicesClientVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.0'">
@@ -33,8 +36,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' AND '$(TargetFramework)' != 'netcoreapp2.0'">
-    <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
-    <PackageReference Include="Microsoft.Data.Services.Client" Version="$(MicrosoftDataServicesClientVersion)" />
+
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Src/SemanticLogging.WindowsAzure/Sinks/WindowsAzureApplicationInsightsSink.cs
+++ b/source/Src/SemanticLogging.WindowsAzure/Sinks/WindowsAzureApplicationInsightsSink.cs
@@ -105,6 +105,8 @@ namespace EnterpriseLibrary.SemanticLogging.Sinks
             AddProperty(GetNonDefaultString(eventEntry.Schema.Version), "Version", telemetry);
             AddProperty(GetNonDefaultString(eventEntry.ActivityId), "ActivityId", telemetry);
             AddProperty(GetNonDefaultString(eventEntry.RelatedActivityId), "RelatedActivityId", telemetry);
+            AddProperty(GetNonDefaultString(eventEntry.Schema.Task), "Task", telemetry);
+            AddProperty(GetNonDefaultString(eventEntry.Schema.TaskName), "TaskName", telemetry);
             AddProperty(eventEntry.Schema.KeywordsDescription, "KeywordsDescription", telemetry);
             for (int i = 0; i < eventEntry.Schema.Payload.Length; i++)
             {
@@ -116,7 +118,7 @@ namespace EnterpriseLibrary.SemanticLogging.Sinks
 
         // Some properties are not useful to include if they have default values; this
         // helper method returns null for those cases so that the properties aren't included.
-        private string GetNonDefaultString<T>(T input) => input.Equals(default(T)) ? null : input.ToString();
+        private string GetNonDefaultString<T>(T input) => input?.Equals(default(T)) ?? true ? null : input.ToString();
 
         private SeverityLevel GetSeverity(EventLevel? eventEntry)
         {

--- a/source/Src/SemanticLogging.WindowsAzure/Sinks/WindowsAzureApplicationInsightsSink.cs
+++ b/source/Src/SemanticLogging.WindowsAzure/Sinks/WindowsAzureApplicationInsightsSink.cs
@@ -1,0 +1,169 @@
+﻿using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using System;
+using System.Diagnostics.Tracing;
+
+namespace EnterpriseLibrary.SemanticLogging.Sinks
+{
+    /// <summary>
+    /// Sink for sending semantic logging telemtry to Application Insights
+    /// </summary>
+    public class WindowsAzureApplicationInsightsSink : IObserver<EventEntry>, IDisposable
+    {
+        private readonly string instanceName;
+        private readonly TelemetryClient telemetryClient;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WindowsAzureApplicationInsightsSink"/> type with the specified instrumentation key.
+        /// </summary>
+        /// <param name="instanceName">The name of the instance originating the entries.</param>
+        /// <param name="instrumentationKey">The instrumentation key for sending telemetry to Application Insights</param>
+        public WindowsAzureApplicationInsightsSink(string instanceName, string instrumentationKey)
+        {
+            // Instance name is stored for later inclusion in telemetry from this sink
+            this.instanceName = instanceName;
+
+            // Set the InstrumentationKey property on TelemetryClient instead of passing in a TelemetryClientConfiguration
+            // to enable retrieving the key later, if needed (as with the ApplicationInsightsTraceListener.InstrumentationKey property)
+            this.telemetryClient = new TelemetryClient()
+            {
+                InstrumentationKey = instrumentationKey
+            };
+        }
+
+        /// <summary>
+        /// The instrumentation key used to record Application Insights telemetry
+        /// </summary>
+        public string InstrumentationKey
+        {
+            get => telemetryClient.InstrumentationKey;
+            set => telemetryClient.InstrumentationKey = value;
+        }
+
+        /// <summary>
+        /// Notifies the observer that the provider has finished sending push-based notifications.
+        /// </summary>
+        public void OnCompleted() => this.Flush();
+
+        private void Flush() => telemetryClient?.Flush();
+
+        /// <summary>
+        /// Notifies the observer that the provider has experienced an error condition.
+        /// </summary>
+        /// <param name="error">An <see cref="Exception"/> providing additional information about the error.</param>
+        public void OnError(Exception error)
+        {
+            if (error != null)
+            {
+                // Application Insights is able to usefully track exceptions
+                telemetryClient.TrackException(error);
+            }
+        }
+
+        /// <summary>
+        /// Provides the sink with new data to write.
+        /// </summary>
+        /// <param name="eventEntry">The current <see cref="EventEntry"/> to write.</param>
+        public void OnNext(EventEntry eventEntry)
+        {
+            // Unlike the SQL and Table Storage sinks, there's no need to buffer events to be
+            // sent here because TelemetryClient already buffers itself.
+            if (eventEntry != null)
+            {
+                telemetryClient.TrackTrace(GetApplicationInsightsTrace(eventEntry));
+            }
+        }
+
+        /// <summary>
+        /// Constructs an Application Insights <see cref="TraceTelemetry"/> object from
+        /// an Enterprise Library <see cref="EventEntry"/>
+        /// </summary>
+        /// <param name="eventEntry">The event to convert into an Application Insights trace</param>
+        /// <returns>An Application Insights trace object</returns>
+        private TraceTelemetry GetApplicationInsightsTrace(EventEntry eventEntry)
+        {
+            var telemetry = new TraceTelemetry(eventEntry.FormattedMessage, GetSeverity(eventEntry.Schema?.Level));
+
+            if (eventEntry.Timestamp != default)
+            {
+                telemetry.Timestamp = eventEntry.Timestamp;
+            }
+
+            // Structured event data is stored as trace properties
+            AddProperty(instanceName, "InstanceName", telemetry);
+            AddProperty(eventEntry.EventId.ToString(), "EventId", telemetry);
+            AddProperty(eventEntry.Schema.EventName, "EventName", telemetry);
+            AddProperty(GetNonDefaultString(eventEntry.ActivityId), "ActivityId", telemetry);
+            AddProperty(eventEntry.Schema.Level.ToString(), "EventLevel", telemetry);
+            AddProperty(GetNonDefaultString(eventEntry.ThreadId), "ThreadId", telemetry);
+            AddProperty(GetNonDefaultString(eventEntry.ProcessId), "ProcessId", telemetry);
+            AddProperty(GetNonDefaultString(eventEntry.ProviderId), "ProviderId", telemetry);
+            AddProperty(eventEntry.Schema.ProviderName, "ProviderName", telemetry);
+            AddProperty(GetNonDefaultString(eventEntry.Schema.Keywords), "Keywords", telemetry);
+            AddProperty(GetNonDefaultString(eventEntry.Schema.Opcode), "Opcode", telemetry);
+            AddProperty(eventEntry.Schema.OpcodeName, "OpcodeName", telemetry);
+            AddProperty(GetNonDefaultString(eventEntry.Schema.Version), "Version", telemetry);
+            AddProperty(GetNonDefaultString(eventEntry.ActivityId), "ActivityId", telemetry);
+            AddProperty(GetNonDefaultString(eventEntry.RelatedActivityId), "RelatedActivityId", telemetry);
+            AddProperty(eventEntry.Schema.KeywordsDescription, "KeywordsDescription", telemetry);
+            for (int i = 0; i < eventEntry.Schema.Payload.Length; i++)
+            {
+                AddProperty(eventEntry.Payload[i].ToString(), eventEntry.Schema.Payload[i], telemetry);
+            }
+
+            return telemetry;
+        }
+
+        // Some properties are not useful to include if they have default values; this
+        // helper method returns null for those cases so that the properties aren't included.
+        private string GetNonDefaultString<T>(T input) => input.Equals(default(T)) ? null : input.ToString();
+
+        private SeverityLevel GetSeverity(EventLevel? eventEntry)
+        {
+            switch(eventEntry)
+            {
+                case EventLevel.Verbose:
+                    return SeverityLevel.Verbose;
+                case EventLevel.Informational:
+                    return SeverityLevel.Information;
+                case EventLevel.Warning:
+                    return SeverityLevel.Warning;
+                case EventLevel.Error:
+                    return SeverityLevel.Error;
+                case EventLevel.Critical:
+                    return SeverityLevel.Critical;
+                default:
+                    return SeverityLevel.Information;
+            }
+        }
+
+        private void AddProperty(string value, string key, TraceTelemetry telemetry)
+        {
+            if (!string.IsNullOrEmpty(key) && !string.IsNullOrEmpty(value))
+            {
+                telemetry.Properties[key] = value;
+            }
+        }
+
+        /// <summary>
+        /// Releases all resources used by the current instance of the <see cref="WindowsAzureApplicationInsightsSink"/> class.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Optionally releases managed resources used by the <see cref="WindowsAzureApplicationInsightsSink"/>
+        /// </summary>
+        /// <param name="disposing">Whether the method is called from <see cref="Dispose()"/></param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.Flush();
+            }
+        }
+    }
+}

--- a/source/Src/SemanticLogging.WindowsAzure/Sinks/WindowsAzureTableSink.cs
+++ b/source/Src/SemanticLogging.WindowsAzure/Sinks/WindowsAzureTableSink.cs
@@ -165,7 +165,7 @@ namespace EnterpriseLibrary.SemanticLogging.Sinks
 
         internal virtual Task<IList<TableResult>> ExecuteBatchAsync(TableBatchOperation batch)
         {
-            return this.table.ExecuteBatchAsync(batch, this.cancellationTokenSource.Token);
+            return this.table.ExecuteBatchAsync(batch, null, null, this.cancellationTokenSource.Token);
         }
 
         internal virtual async Task<bool> EnsureTableExistsAsync()
@@ -178,7 +178,7 @@ namespace EnterpriseLibrary.SemanticLogging.Sinks
 
             try
             {
-                await this.table.CreateIfNotExistsAsync(token).ConfigureAwait(false);
+                await this.table.CreateIfNotExistsAsync(null, null, token).ConfigureAwait(false);
                 return true;
             }
             catch (OperationCanceledException)

--- a/source/Src/SemanticLogging.WindowsAzure/WindowsAzureApplicationInsightsLog.cs
+++ b/source/Src/SemanticLogging.WindowsAzure/WindowsAzureApplicationInsightsLog.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Diagnostics.Tracing;
+using EnterpriseLibrary.SemanticLogging.Sinks;
+
+namespace EnterpriseLibrary.SemanticLogging
+{
+    /// <summary>
+    /// Factories and helpers for using the <see cref="WindowsAzureApplicationInsightsSink"/>.
+    /// </summary>
+    public static class WindowsAzureApplicationInsightsLog
+    {
+        /// <summary>
+        /// Creates an event listener that logs using a <see cref="WindowsAzureApplicationInsightsSink" />.
+        /// </summary>
+        /// <param name="instanceName">The name of the instance originating the entries.</param>
+        /// <param name="instrumentationKey">The instrumentation key for sending telemetry to Application Insights</param>
+        /// <returns>An event listener that uses <see cref="WindowsAzureApplicationInsightsSink"/> to log events.</returns>
+        public static EventListener CreateListener(string instanceName, string instrumentationKey)
+        {
+            var listener = new ObservableEventListener();
+            listener.LogToWindowsAzureApplicationInsights(instanceName, instrumentationKey);
+            return listener;
+        }
+
+        /// <summary>
+        /// Subscribes to an <see cref="IObservable{EventEntry}" /> using a <see cref="WindowsAzureApplicationInsightsSink" />.
+        /// </summary>
+        /// <param name="eventStream">The event stream. Typically this is an instance of <see cref="ObservableEventListener" />.</param>
+        /// <param name="instanceName">The name of the instance originating the entries.</param>
+        /// <param name="instrumentationKey">The instrumentation key for sending telemetry to Application Insights</param>
+        /// <returns>A subscription to the sink that can be disposed to unsubscribe the sink and dispose it, or to get access to the sink instance.</returns>
+        public static SinkSubscription<WindowsAzureApplicationInsightsSink> LogToWindowsAzureApplicationInsights(this IObservable<EventEntry> eventStream, string instanceName, string instrumentationKey)
+        {
+            var sink = new WindowsAzureApplicationInsightsSink(instanceName, instrumentationKey);
+            var subscription = eventStream.Subscribe(sink);
+            return new SinkSubscription<WindowsAzureApplicationInsightsSink>(subscription, sink);
+        }
+    }
+}

--- a/source/Tests/SemanticLogging.Tests/SemanticLogging.Tests.csproj
+++ b/source/Tests/SemanticLogging.Tests/SemanticLogging.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net47</TargetFrameworks>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
@@ -19,8 +19,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0-beta2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0-beta2" />
+
+    <PackageReference Include="Microsoft.Data.Services.Client" Version="$(MicrosoftDataServicesClientVersion)" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingTraceEventVersion)" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
+    <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,7 +36,6 @@
     <ProjectReference Include="..\..\Src\SemanticLogging.EventSourceAnalyzer\SemanticLogging.EventSourceAnalyzer.csproj" />
     <ProjectReference Include="..\..\Src\SemanticLogging.WindowsAzure\SemanticLogging.WindowsAzure.csproj" />
     <ProjectReference Include="..\..\Src\SemanticLogging.Database\SemanticLogging.Database.csproj" />
-    <ProjectReference Include="..\..\Src\SemanticLogging.Etw\SemanticLogging.Etw.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.0'">
@@ -45,9 +51,7 @@
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web.Extensions" />
 
-    <PackageReference Include="Microsoft.Data.Services.Client" Version="$(MicrosoftDataServicesClientVersion)" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingTraceEventVersion)" />
-    <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
+    <ProjectReference Include="..\..\Src\SemanticLogging.Etw\SemanticLogging.Etw.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -214,6 +218,18 @@
 
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.0'">
+    <Compile Remove="**\*.PartialTrust.cs" />
+    <Compile Remove="Etw\**\*.cs" />
+    <Compile Remove="TestSupport\AssemblyBuilder.cs" />
+    <Compile Remove="TestSupport\DisposableDomain.cs" />
+    <Compile Remove="UsingEventListener\DeferredEnablementFixture.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' AND '$(TargetFramework)' != 'netcoreapp2.0'">
+    <Compile Remove="TestSupport\NetCoreExtensions.cs" />
+  </ItemGroup>
+      
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/source/Tests/SemanticLogging.Tests/Sinks/ApplicationInsightsSinkTests.cs
+++ b/source/Tests/SemanticLogging.Tests/Sinks/ApplicationInsightsSinkTests.cs
@@ -1,0 +1,282 @@
+﻿using EnterpriseLibrary.SemanticLogging.Schema;
+using EnterpriseLibrary.SemanticLogging.Sinks;
+using EnterpriseLibrary.SemanticLogging.Tests.TestSupport;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics.Tracing;
+using System.Linq;
+
+namespace EnterpriseLibrary.SemanticLogging.Tests.Sinks
+{
+    [TestClass]
+    public class ApplicationInsightsSinkTests
+    {
+        const string InstanceName = "InstanceName";
+        const string InstrumentationKey = "InstrumentationKey";
+
+        MockApplicationInsightsTelemetryChannel TelemetryChannel;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Intercept AI telemetry client
+            TelemetryChannel = new MockApplicationInsightsTelemetryChannel();
+            TelemetryConfiguration.Active.TelemetryChannel = TelemetryChannel;
+        }
+
+        [TestMethod]
+        public void ExtensionMethodsCreateSinkProperly()
+        {
+            TelemetryChannel.ResetTelemetry();
+
+            using (var listener = WindowsAzureApplicationInsightsLog.CreateListener(InstanceName, InstrumentationKey))
+            {
+                listener.EnableEvents(TestEventSource.Log, EventLevel.Informational);
+                TestEventSource.Log.LogWarning("Test message");
+            }
+
+            var trace = TelemetryChannel.Traces.SingleOrDefault() as TraceTelemetry;
+
+            Assert.IsNotNull(trace);
+            Assert.AreEqual("Warning Event", trace.Message);
+            Assert.AreEqual(SeverityLevel.Warning, trace.SeverityLevel);
+            Assert.AreEqual(InstrumentationKey, trace.Context.InstrumentationKey);
+            AssertHasProperty(trace, "message", "Test message");
+            AssertHasProperty(trace, "InstanceName", InstanceName);
+        }
+
+        [TestMethod]
+        public void PropertiesSetCorrectly()
+        {
+            using (var sink = new WindowsAzureApplicationInsightsSink(null, InstrumentationKey))
+            {
+                Assert.AreEqual(InstrumentationKey, sink.InstrumentationKey);
+            }
+
+            Assert.ThrowsException<ArgumentNullException>(() => new WindowsAzureApplicationInsightsSink(InstanceName, null));
+        }
+
+        [TestMethod]
+        public void FlushesOnDispose()
+        {
+            TelemetryChannel.ResetTelemetry();
+
+            using (var sink = new WindowsAzureApplicationInsightsSink(InstanceName, InstrumentationKey))
+            {
+                Assert.AreEqual(0, TelemetryChannel.FlushCount);
+
+                sink.OnCompleted();
+
+                Assert.AreEqual(1, TelemetryChannel.FlushCount);
+            }
+
+            Assert.AreEqual(0, TelemetryChannel.Traces.Count);
+            Assert.AreEqual(2, TelemetryChannel.FlushCount);
+        }
+
+        // Confirm that events are sent to AppInsights, including both implicit and explicit properties
+        [TestMethod]
+        public void SendsEventsToApplicationInsights()
+        {
+            TelemetryChannel.ResetTelemetry();
+
+            var eventEntry = new EventEntry(
+                Guid.NewGuid(),
+                11,
+                "Test Message",
+                new ReadOnlyCollection<object>(new object[] { "Value", 5 }),
+                DateTimeOffset.Now.AddMinutes(-5),
+                100,
+                200,
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                new EventSchema(
+                    11,
+                    Guid.NewGuid(),
+                    "MyProvider",
+                    EventLevel.Warning,
+                    EventTask.None,
+                    "None",
+                    EventOpcode.Start,
+                    "Info",
+                    EventKeywords.EventLogClassic,
+                    "EventLogClassic",
+                    4,
+                    new[] { "Key", "Number" }));
+
+            using (var sink = new WindowsAzureApplicationInsightsSink(InstanceName, InstrumentationKey))
+            {
+                sink.OnNext(eventEntry);
+            }
+
+            var trace = TelemetryChannel.Traces.SingleOrDefault() as TraceTelemetry;
+
+            Assert.IsNotNull(trace);
+            Assert.AreEqual(eventEntry.Timestamp, trace.Timestamp);
+            Assert.AreEqual(SeverityLevel.Warning, trace.SeverityLevel);
+            Assert.AreEqual(eventEntry.FormattedMessage, trace.Message);
+            Assert.AreEqual(InstrumentationKey, trace.Context.InstrumentationKey);
+            AssertHasProperty(trace, "InstanceName", InstanceName);
+            AssertHasProperty(trace, "Key", "Value");
+            AssertHasProperty(trace, "Number", "5");
+            AssertHasProperty(trace, "ActivityId", eventEntry.ActivityId.ToString());
+            AssertHasProperty(trace, "EventId", eventEntry.EventId.ToString());
+            AssertHasProperty(trace, "ProcessId", eventEntry.ProcessId.ToString());
+            AssertHasProperty(trace, "ProviderId", eventEntry.ProviderId.ToString());
+            AssertHasProperty(trace, "RelatedActivityId", eventEntry.RelatedActivityId.ToString());
+            AssertHasProperty(trace, "ThreadId", eventEntry.ThreadId.ToString());
+            AssertHasProperty(trace, "EventName", eventEntry.Schema.EventName.ToString());
+            AssertHasProperty(trace, "Keywords", eventEntry.Schema.Keywords.ToString());
+            AssertHasProperty(trace, "KeywordsDescription", eventEntry.Schema.KeywordsDescription.ToString());
+            AssertHasProperty(trace, "Opcode", eventEntry.Schema.Opcode.ToString());
+            AssertHasProperty(trace, "OpcodeName", eventEntry.Schema.OpcodeName.ToString());
+            AssertHasProperty(trace, "ProviderName", eventEntry.Schema.ProviderName.ToString());
+            AssertDoesNotHaveProperty(trace, "Task");
+            AssertHasProperty(trace, "TaskName", eventEntry.Schema.TaskName.ToString());
+            AssertHasProperty(trace, "Version", eventEntry.Schema.Version.ToString());
+        }
+
+        // Confirm that null/default properties aren't include in traces
+        [TestMethod]
+        public void DefaultPropertiesNotTraced()
+        {
+            TelemetryChannel.ResetTelemetry();
+
+            var eventEntry = new EventEntry(
+                Guid.Empty,
+                0,
+                null,
+                null,
+                default,
+                0,
+                0,
+                Guid.Empty,
+                Guid.Empty,
+                new EventSchema(
+                    0,
+                    Guid.Empty,
+                    null,
+                    EventLevel.LogAlways,
+                    EventTask.None,
+                    null,
+                    EventOpcode.Info,
+                    null,
+                    EventKeywords.None,
+                    null,
+                    0,
+                    Enumerable.Empty<string>()));
+
+            using (var sink = new WindowsAzureApplicationInsightsSink(null, InstrumentationKey))
+            {
+                sink.OnNext(eventEntry);
+            }
+
+            var trace = TelemetryChannel.Traces.SingleOrDefault() as TraceTelemetry;
+
+            Assert.IsNotNull(trace);
+
+            // Default AppInsights timestamp (DateTimeOffset.Now) used if none is specified
+            Assert.AreNotEqual(eventEntry.Timestamp, trace.Timestamp);
+            Assert.IsTrue(trace.Timestamp > DateTimeOffset.Now.AddMinutes(-1));
+
+            Assert.AreEqual(SeverityLevel.Information, trace.SeverityLevel);
+            Assert.AreEqual(eventEntry.FormattedMessage, trace.Message);
+            Assert.AreEqual(InstrumentationKey, trace.Context.InstrumentationKey);
+
+            AssertHasProperty(trace, "EventId", "0");
+
+            AssertDoesNotHaveProperty(trace, "InstanceName");
+            AssertDoesNotHaveProperty(trace, "Key");
+            AssertDoesNotHaveProperty(trace, "ActivityId");
+            AssertDoesNotHaveProperty(trace, "ProcessId");
+            AssertDoesNotHaveProperty(trace, "ProviderId");
+            AssertDoesNotHaveProperty(trace, "RelatedActivityId");
+            AssertDoesNotHaveProperty(trace, "ThreadId");
+            AssertDoesNotHaveProperty(trace, "EventName");
+            AssertDoesNotHaveProperty(trace, "Keywords");
+            AssertDoesNotHaveProperty(trace, "KeywordsDescription");
+            AssertDoesNotHaveProperty(trace, "Opcode");
+            AssertDoesNotHaveProperty(trace, "OpcodeName");
+            AssertDoesNotHaveProperty(trace, "ProviderName");
+            AssertDoesNotHaveProperty(trace, "Task");
+            AssertDoesNotHaveProperty(trace, "TaskName");
+            AssertDoesNotHaveProperty(trace, "Version");
+        }
+
+        [DataTestMethod]
+        [DataRow(EventLevel.Critical, SeverityLevel.Critical)]
+        [DataRow(EventLevel.Error, SeverityLevel.Error)]
+        [DataRow(EventLevel.Informational, SeverityLevel.Information)]
+        [DataRow(EventLevel.LogAlways, SeverityLevel.Information)]
+        [DataRow(EventLevel.Verbose, SeverityLevel.Verbose)]
+        [DataRow(EventLevel.Warning, SeverityLevel.Warning)]
+        public void EventLevelsAreTranslatedToSeverityLevels(EventLevel eventLevel, SeverityLevel severityLevel)
+        {
+            var eventEntry = EventEntryTestHelper.Create(level: eventLevel);
+            TelemetryChannel.ResetTelemetry();
+
+            using (var sink = new WindowsAzureApplicationInsightsSink(null, InstrumentationKey))
+            {
+                sink.OnNext(eventEntry);
+            }
+
+            var trace = TelemetryChannel.Traces.SingleOrDefault() as TraceTelemetry;
+
+            Assert.IsNotNull(trace);
+            Assert.AreEqual(severityLevel, trace.SeverityLevel);
+        }
+
+        [TestMethod]
+        public void SendExceptionsToApplicationInsights()
+        {
+            TelemetryChannel.ResetTelemetry();
+
+            var exc = new BadImageFormatException("TestMessage");
+            using (var sink = new WindowsAzureApplicationInsightsSink(InstanceName, InstrumentationKey))
+            {
+                sink.OnError(exc);
+            }
+
+            var trace = TelemetryChannel.Traces.SingleOrDefault() as ExceptionTelemetry;
+
+            Assert.IsNotNull(trace);
+            Assert.AreEqual(exc, trace.Exception);
+            Assert.AreEqual(null, trace.Message);
+            Assert.AreEqual(null, trace.SeverityLevel);
+            Assert.AreEqual(0, trace.Properties.Count);
+
+            var excDetails = trace.ExceptionDetailsInfoList.SingleOrDefault();
+            Assert.IsNotNull(excDetails);
+            Assert.AreEqual(exc.Message, excDetails.Message);
+            Assert.AreEqual(exc.GetType().ToString(), excDetails.TypeName);
+        }
+
+        private void AssertDoesNotHaveProperty(TraceTelemetry telemetry, string key)
+        {
+            Assert.IsTrue(!telemetry.Properties.ContainsKey(key));
+        }
+
+        public void AssertHasProperty(TraceTelemetry telemetry, string key, string expectedValue)
+        {
+            Assert.AreEqual(expectedValue, telemetry.Properties[key]);
+        }
+
+        [EventSource(Name = "Test Event Source")]
+        private class TestEventSource : EventSource
+        {
+            public static TestEventSource Log = new TestEventSource();
+
+            [Event(1, Message = "Warning Event", Level = EventLevel.Warning)]
+            public void LogWarning(string message)
+            {
+                if (IsEnabled())
+                {
+                    WriteEvent(1, message);
+                }
+            }
+        }
+    }
+}

--- a/source/Tests/SemanticLogging.Tests/Sinks/SqlDatabaseSinkTests.cs
+++ b/source/Tests/SemanticLogging.Tests/Sinks/SqlDatabaseSinkTests.cs
@@ -19,8 +19,8 @@ namespace EnterpriseLibrary.SemanticLogging.Tests.Sinks
     [TestClass]
     public class sql_db_sink_given_configuration
     {
-        private static readonly string ValidConnectionString = ConfigurationManager.ConnectionStrings["valid"].ConnectionString;
-        private static readonly string InvalidConnectionString = ConfigurationManager.ConnectionStrings["invalid"].ConnectionString;
+        private static readonly string ValidConnectionString = ConfigurationHelper.GetConnectionString("valid");
+        private static readonly string InvalidConnectionString = ConfigurationHelper.GetConnectionString("invalid");
 
         [TestMethod]
         public void when_creating_listener_for_null_instance_name_then_throws()

--- a/source/Tests/SemanticLogging.Tests/TestSupport/ConfigurationHelper.cs
+++ b/source/Tests/SemanticLogging.Tests/TestSupport/ConfigurationHelper.cs
@@ -21,10 +21,27 @@ namespace EnterpriseLibrary.SemanticLogging.Tests.TestSupport
 
             if (string.IsNullOrEmpty(value))
             {
-                value = ConfigurationManager.AppSettings[settingName];
+                var configuration =
+#if NETCOREAPP
+                    ConfigurationManager.OpenMappedExeConfiguration(new ExeConfigurationFileMap { ExeConfigFilename = "EnterpriseLibrary.SemanticLogging.Tests.dll.config" }, ConfigurationUserLevel.None);
+#else
+                    ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+#endif
+                value = configuration.AppSettings.Settings[settingName]?.Value;
             }
 
             return value;
+        }
+
+        public static string GetConnectionString(string connectionStringName)
+        {
+            var configuration =
+#if NETCOREAPP
+                    ConfigurationManager.OpenMappedExeConfiguration(new ExeConfigurationFileMap { ExeConfigFilename = "EnterpriseLibrary.SemanticLogging.Tests.dll.config" }, ConfigurationUserLevel.None);
+#else
+                    ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+#endif
+            return configuration.ConnectionStrings.ConnectionStrings[connectionStringName]?.ConnectionString;
         }
     }
 }

--- a/source/Tests/SemanticLogging.Tests/TestSupport/MockApplicationInsightsTelemetryChannel.cs
+++ b/source/Tests/SemanticLogging.Tests/TestSupport/MockApplicationInsightsTelemetryChannel.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using Microsoft.ApplicationInsights.Channel;
+
+namespace EnterpriseLibrary.SemanticLogging.Tests.TestSupport
+{
+    /// <summary>
+    /// Test class for mocking Application Insights communication
+    /// Stores telemetry that would have been sent and tracks flush count
+    /// </summary>
+    internal class MockApplicationInsightsTelemetryChannel : ITelemetryChannel
+    {
+        public List<ITelemetry> Traces { get; private set; }
+        public int FlushCount { get; private set; }
+
+        public MockApplicationInsightsTelemetryChannel()
+        {
+            ResetTelemetry();
+        }
+
+        public void ResetTelemetry()
+        {
+            Traces = new List<ITelemetry>();
+            FlushCount = 0;
+        }
+
+        public bool? DeveloperMode { get; set; }
+        public string EndpointAddress { get; set; }
+
+        public void Dispose() { }
+
+        public void Flush() => FlushCount++;
+
+        public void Send(ITelemetry item) => Traces.Add(item);
+    }
+}

--- a/source/Tests/SemanticLogging.Tests/TestSupport/NetCoreExtensions.cs
+++ b/source/Tests/SemanticLogging.Tests/TestSupport/NetCoreExtensions.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Table;
+using System.Collections.Generic;
+
+namespace EnterpriseLibrary.SemanticLogging.Tests
+{
+    public static class NetCoreExtensions
+    {
+        public static bool CreateIfNotExists(this CloudTable table, TableRequestOptions requestOptions = null, OperationContext operationContext = null) =>
+            table.CreateIfNotExistsAsync(requestOptions, operationContext).Result;
+
+        public static void Delete(this CloudTable table, TableRequestOptions requestOptions = null, OperationContext operationContext = null) =>
+            table.DeleteAsync(requestOptions, operationContext).Wait();
+
+        public static bool DeleteIfExists(this CloudTable table, TableRequestOptions requestOptions = null, OperationContext operationContext = null) =>
+            table.DeleteIfExistsAsync(requestOptions, operationContext).Result;
+
+        public static IEnumerable<TElement> ExecuteQuery<TElement>(this CloudTable table, TableQuery<TElement> query, TableRequestOptions requestOptions = null, OperationContext operationContext = null) where TElement : ITableEntity, new()
+        {
+            var results = new List<TElement>();
+            var segment = table.ExecuteQuerySegmentedAsync(query, null, requestOptions, operationContext).Result;
+            results.AddRange(segment.Results);
+            while (segment.ContinuationToken != null)
+            {
+                segment = table.ExecuteQuerySegmentedAsync(query, segment.ContinuationToken, requestOptions, operationContext).Result;
+                results.AddRange(segment.Results);
+            }
+
+            return results;
+        }
+    }
+}


### PR DESCRIPTION
This PR enables unit tests on .NET Core and adds a couple Azure-focused sinks:

- Re-enables Azure table storage log/sink for .NET Core
- Adds a new Application Insights log/sink for logging to AppInsights